### PR TITLE
read_csv should not skip the last track object

### DIFF
--- a/Python/src/data_management/read_csv.py
+++ b/Python/src/data_management/read_csv.py
@@ -74,7 +74,7 @@ def read_track_csv(arguments):
     df = pandas.read_csv(arguments["input_path"])
 
     # Use groupby to aggregate track info. Less error prone than iterating over the data.
-    grouped = df.groupby([TRACK_ID])
+    grouped = df.groupby([TRACK_ID], sort=False)
     # Efficiently pre-allocate an empty list of sufficient size
     tracks = [None] * grouped.ngroups
     current_track = 0

--- a/Python/src/data_management/read_csv.py
+++ b/Python/src/data_management/read_csv.py
@@ -73,56 +73,40 @@ def read_track_csv(arguments):
     # Read the csv file, convert it into a useful data structure
     df = pandas.read_csv(arguments["input_path"])
 
-    # Declare and initialize the tracks list and some variables
-    tracks = []
-    actual_id = -1
-    track_length = 0
-
-    # Iterate over all rows of the csv because we need to create the bounding boxes for each row
-    for i_row in range(df.shape[0]):
-        i_track_id = df[TRACK_ID][i_row]
-        # Set the first track_id
-        if actual_id == -1:
-            actual_id = i_track_id
-
-        # Create the dictionary for each track. Using mostly vectorized code to be faster and save memory
-        if actual_id != i_track_id:
-            starting_index = int(i_row - track_length)
-            r = list(range(starting_index, i_row))
-            bounding_boxes = np.transpose(np.array([df[X][r].values,
-                                                    df[Y][r].values,
-                                                    df[WIDTH][r].values,
-                                                    df[HEIGHT][r].values]))
-            track = {TRACK_ID: actual_id,
-                     FRAME: df[FRAME][r].values,
-                     BBOX: bounding_boxes,
-                     X_VELOCITY: df[X_VELOCITY][r].values,
-                     Y_VELOCITY: df[Y_VELOCITY][r].values,
-                     X_ACCELERATION: df[X_ACCELERATION][r].values,
-                     Y_ACCELERATION: df[Y_ACCELERATION][r].values,
-                     FRONT_SIGHT_DISTANCE: df[FRONT_SIGHT_DISTANCE][r].values,
-                     BACK_SIGHT_DISTANCE: df[BACK_SIGHT_DISTANCE][r].values,
-                     THW: df[THW][r].values,
-                     TTC: df[TTC][r].values,
-                     DHW: df[DHW][r].values,
-                     PRECEDING_X_VELOCITY: df[PRECEDING_X_VELOCITY][r].values,
-                     PRECEDING_ID: df[PRECEDING_ID][r].values,
-                     FOLLOWING_ID: df[FOLLOWING_ID][r].values,
-                     LEFT_FOLLOWING_ID: df[LEFT_FOLLOWING_ID][r].values,
-                     LEFT_ALONGSIDE_ID: df[LEFT_ALONGSIDE_ID][r].values,
-                     LEFT_PRECEDING_ID: df[LEFT_PRECEDING_ID][r].values,
-                     RIGHT_FOLLOWING_ID: df[RIGHT_FOLLOWING_ID][r].values,
-                     RIGHT_ALONGSIDE_ID: df[RIGHT_ALONGSIDE_ID][r].values,
-                     RIGHT_PRECEDING_ID: df[RIGHT_PRECEDING_ID][r].values,
-                     LANE_ID: df[LANE_ID][r].values
-                     }
-            # Reset the bounding boxes list and set the new track id
-            actual_id = i_track_id
-            track_length = 0
-
-            # Add the new track to the tracks list
-            tracks.append(track)
-        track_length += 1
+    # Use groupby to aggregate track info. Less error prone than iterating over the data.
+    grouped = df.groupby([TRACK_ID])
+    # Efficiently pre-allocate an empty list of sufficient size
+    tracks = [None] * grouped.ngroups
+    current_track = 0
+    for group_id, rows in grouped:
+        bounding_boxes = np.transpose(np.array([rows[X].values,
+                                                rows[Y].values,
+                                                rows[WIDTH].values,
+                                                rows[HEIGHT].values]))
+        tracks[current_track] = {TRACK_ID: np.int64(group_id),  # for compatibility, int would be more space efficient
+                                 FRAME: rows[FRAME].values,
+                                 BBOX: bounding_boxes,
+                                 X_VELOCITY: rows[X_VELOCITY].values,
+                                 Y_VELOCITY: rows[Y_VELOCITY].values,
+                                 X_ACCELERATION: rows[X_ACCELERATION].values,
+                                 Y_ACCELERATION: rows[Y_ACCELERATION].values,
+                                 FRONT_SIGHT_DISTANCE: rows[FRONT_SIGHT_DISTANCE].values,
+                                 BACK_SIGHT_DISTANCE: rows[BACK_SIGHT_DISTANCE].values,
+                                 THW: rows[THW].values,
+                                 TTC: rows[TTC].values,
+                                 DHW: rows[DHW].values,
+                                 PRECEDING_X_VELOCITY: rows[PRECEDING_X_VELOCITY].values,
+                                 PRECEDING_ID: rows[PRECEDING_ID].values,
+                                 FOLLOWING_ID: rows[FOLLOWING_ID].values,
+                                 LEFT_FOLLOWING_ID: rows[LEFT_FOLLOWING_ID].values,
+                                 LEFT_ALONGSIDE_ID: rows[LEFT_ALONGSIDE_ID].values,
+                                 LEFT_PRECEDING_ID: rows[LEFT_PRECEDING_ID].values,
+                                 RIGHT_FOLLOWING_ID: rows[RIGHT_FOLLOWING_ID].values,
+                                 RIGHT_ALONGSIDE_ID: rows[RIGHT_ALONGSIDE_ID].values,
+                                 RIGHT_PRECEDING_ID: rows[RIGHT_PRECEDING_ID].values,
+                                 LANE_ID: rows[LANE_ID].values
+                                 }
+        current_track = current_track + 1
     return tracks
 
 


### PR DESCRIPTION
Fixes #1 

The former algorithm created a new track if and only if there exists an entry in the CSV which has a higher track id. Therefore, the last track will always be skipped (as there is no change in the track id anymore).

I replaced the implementation with a `groupby` call to the pandas dataframe while applying some optimizations here and there. This completely fixes the issue described above and also improves the speed of the reading algorithm.

`groupby` is guaranteed to keep the order of the elements for each group, as well as the order of the groups as they appear in the dataframe. This will not throw any errors if a track_id is reused, which matches the implementation of the previous algorithm.

The resulting pickle files are identical if I drop the last track object before writing the result to the pickle file, i.e.,
`$ sha256sum 01_new_algorithm.pickle 01_old_algorithm.pickle
f5445ce4761e8c31c109ac83dbfa91be84d6a9b7d451fa0b77a5af032cd9063a *01_new_algorithm.pickle
f5445ce4761e8c31c109ac83dbfa91be84d6a9b7d451fa0b77a5af032cd9063a *01_old_algorithm.pickle`

Therefore the algorithm is correct while offering easier maintainability.

Remark: I had to use np.int64 to save the track_id, which is probably overkill but was necessary to yield the same hash.